### PR TITLE
Fix path square brackets issue

### DIFF
--- a/nextfile.lua
+++ b/nextfile.lua
@@ -45,8 +45,10 @@ function get_files_windows(dir)
               Write-Error -ErrorRecord $_
               Exit 1
           }
-          cd "]]..dir..[["
-
+          $path = "]]..dir..[["
+          $escapedPath = [WildcardPattern]::Escape($path)
+          cd $escapedPath
+    
           $list = (Get-ChildItem -File | Sort-Object { [regex]::Replace($_.Name, '\d+', { $args[0].Value.PadLeft(20) }) }).Name
           $string = ($list -join "/")
           $u8list = [System.Text.Encoding]::UTF8.GetBytes($string)


### PR DESCRIPTION
Fixed in Windows OS,
paths that contained square brackets "[" caused script to break.